### PR TITLE
Example showing usage of dbs files

### DIFF
--- a/dbs_example.xml
+++ b/dbs_example.xml
@@ -1,0 +1,11 @@
+<channel name="dbs_example" guid="00000000000000000000000000000000" description="This channel is an LLP listener that accepts incoming HL7 messages and then stores some of the information to a database.&#xD;&#xA;&#xD;&#xA;The Source component listens for messages on port 5145. &#xD;&#xA;&#xD;&#xA;The Filter component filters out any message that is not an HL7 ADT message.&#xD;&#xA;&#xD;&#xA;The Destination component inserts some of the fields from the message into a SQLite database.&#xD;&#xA;&#xD;&#xA;More information: http://wiki.interfaceware.com/1370.html" start_automatically="true" logging_level="1" use_message_filter="true">
+   <to_mapper guid="00000000000000000000000000000000" use_most_recent_milestone="true" milestone="">
+      <dequeue_list>
+         <dequeue source_name="self" dequeue_guid="9DDF709B1F7E0D369A8215186AAC1514"></dequeue>
+      </dequeue_list>
+   </to_mapper>
+   <from_llp_listener ack_vmd_path="${iguana_dir}/autoack.vmd" nack_vmd_path="autonack.vmd" port="5145" nack_all_errors="false" connection_timeout="1" unlimited_connection_timeout="true" ack_style="fast" check_remote_host="false" remote_host="" alternate_remote_host="" message_encoding="" escape_8bit="false" escape_char="" use_ssl="false" ssl_certificate_file="" ssl_private_key_file="" ssl_verify_peer="true" ssl_certificate_authority="" ipv6_support="false" llp_start="\x0B" llp_end="\x1C\x0D"></from_llp_listener>
+   <message_filter filter_after_logging="true" log_pre_post_filter_message="true" filter_vmd_path="" transformation_mode="0" scripted_transformation_configuration_name="default" incoming_configuration_name="" outgoing_configuration_name="" error_handling="0" use_translator_filter="true" translator_guid="00000000000000000000000000000000" translator_milestone="" translator_use_most_recent_milestone="true">
+      <ignored_message message_name=""></ignored_message>
+   </message_filter>
+</channel>

--- a/dbs_example_filter/main.lua
+++ b/dbs_example_filter/main.lua
@@ -1,0 +1,30 @@
+-- This filter script removes everything from the queue except ADT (Admit/Discharge/Transfer) messages.
+
+-- For each incoming message, Iguana will call the 'main' function. 
+-- Its argument is a raw string containing the unparsed message.
+
+require 'node'  -- Add the shared module 'node' to this script
+
+function main(RawMsgIn)
+   -- Keep this channel running even in the event of error
+   iguana.stopOnError(false)
+   
+   -- Parse incoming raw messages with the hl7.parse function.
+   -- This will return the parsed message 'MsgIn' and message type 'MsgType'
+   local MsgIn, MsgType = hl7.parse{vmd='example/demo.vmd', data=RawMsgIn}
+   
+   -- Build the outgoing HL7 Message template
+   local MsgOut = hl7.message{vmd='example/demo.vmd', name=MsgType}
+   
+   -- Copy all fields from MsgIn to MsgOut
+   MsgOut:mapTree(MsgIn)
+   
+   -- Filter the parsed messages for ADT messages, discarding all the others.
+   
+   if MsgType == 'ADT' then
+      -- Push ADT messages back into the queue.      
+      -- NOTE: We use the shorthand :S() notation to convert the 
+      -- parsed message back to a string. 
+      queue.push{data=MsgOut:S()}
+   end 
+end

--- a/dbs_example_filter/project.prj
+++ b/dbs_example_filter/project.prj
@@ -1,0 +1,9 @@
+{
+   "Name": "02-Socket to Database (Filter)",
+   "LuaDependencies": [
+      "node"
+   ],
+   "OtherDependencies": [
+      "example/demo.vmd"
+   ]
+}

--- a/dbs_example_to/main.lua
+++ b/dbs_example_to/main.lua
@@ -1,0 +1,42 @@
+-- This script maps specific patient data to an external database.
+-- (this does the same thing as the 02 - Socket to Database demo channel
+--  except that it loads the table schema from dbs file instead of vmd file)
+
+require "dbs_meta"
+
+-- Connect to database
+DB = db.connect{api=db.SQLITE, name='Demo/PatientData.sqlite'}
+-- load a copy of table schema from tables.dbs file
+Schema = dbs.tableLayoutFromFile{filename="tables.dbs"}
+-- create the tables in database if they don't already exist
+dbs_create_tables(Connection, Schema)
+
+function main(Data)
+   -- Connection:execute{sql="drop table Patient", live=true}
+   
+   -- Parse incoming raw message with hl7.parse
+   local MsgIn = hl7.parse{vmd='example/demo.vmd', data=Data}
+
+   local TableOut = Schema:getTableSet("ADT");
+   
+   -- Map fields from PID segment to Patient table
+   MapPatient(TableOut.Patient[1], MsgIn.PID)
+   
+   -- Insert information from TableOut into the real table
+   DB:merge{data=TableOut, live=false}
+   -- Change the above live=false to live=true 
+   
+   -- Remove comment below and click Result Set in the
+   -- annotations to the right
+   DB:query{sql='Select * from Patient'}
+end
+
+function MapPatient(Patient, PID)
+   -- This function prepares the TableOut variable
+   Patient.Id        = PID[3][1][1]
+   Patient.FirstName = PID[5][1][2]
+   Patient.LastName  = PID[5][1][1][1]
+   Patient.Gender    = PID[8]   
+   -- Click the Patient Row to the right to see results
+   return Patient
+end

--- a/dbs_example_to/project.prj
+++ b/dbs_example_to/project.prj
@@ -1,0 +1,10 @@
+{
+   "Name": "02-Socket to Database (To Translator)",
+   "LuaDependencies": [
+      "dbs_meta"
+   ],
+   "OtherDependencies": [
+      "example/demo.vmd",
+      "tables.dbs"
+   ]
+}

--- a/other/example/demo.vmd
+++ b/other/example/demo.vmd
@@ -1,0 +1,12652 @@
+<engine version="1.0">
+   <strict_grammar_checking>False</strict_grammar_checking>
+   <java_use_native_double>False</java_use_native_double>
+   <use_passthrough_mapping>False</use_passthrough_mapping>
+   <current_config>0</current_config>
+   <incoming_config>0</incoming_config>
+   <outgoing_config>0</outgoing_config>
+   <vmd_description></vmd_description>
+   <use_dotnet_properties>True</use_dotnet_properties>
+   <global name="global">
+      <table name="patient">
+         <description>Patient table</description>
+         <action>1</action>
+         <column name="Id">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="LastName">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="GivenName">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Race">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="PhoneHome">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="PhoneBusiness">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Religion">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="MaritalStatus">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Ssn">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="LicenseNumber">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Dob">
+            <description></description>
+            <type>DateTime</type>
+         </column>
+         <column name="Sex">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Weight">
+            <description></description>
+            <type>String</type>
+         </column>
+      </table>
+      <table name="kin">
+         <description>Next of kin</description>
+         <action>1</action>
+         <column name="PatientId">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="LastName">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="FirstName">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="Relationship">
+            <description></description>
+            <type>String</type>
+         </column>
+      </table>
+      <table name="visitinformation">
+         <description>Visit Table</description>
+         <action>1</action>
+         <column name="PatientClass">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="AdmitType">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="AdmitSource">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="HospitalService">
+            <description></description>
+            <type>String</type>
+         </column>
+         <column name="PatientType">
+            <description></description>
+            <type>String</type>
+         </column>
+      </table>
+      <message name="ADT">
+         <description>Admit/visit notification</description>
+         <table_grammar name="ADT">
+            <type>group</type>
+            <table_grammar name="patient">
+               <type>table</type>
+               <table_ref>patient</table_ref>
+            </table_grammar>
+            <table_grammar name="kin">
+               <type>table</type>
+               <table_ref>kin</table_ref>
+            </table_grammar>
+            <table_grammar name="visitinformation">
+               <type>table</type>
+               <table_ref>visitinformation</table_ref>
+            </table_grammar>
+         </table_grammar>
+      </message>
+      <message name="Catchall">
+         <description></description>
+         <table_grammar name="Catchall">
+            <type>group</type>
+         </table_grammar>
+      </message>
+      <message name="Lab">
+         <description>Unsolicited transmission of an observation message</description>
+         <table_grammar name="Lab">
+            <type>group</type>
+            <table_grammar name="patient">
+               <type>table</type>
+               <table_ref>patient</table_ref>
+            </table_grammar>
+            <table_grammar name="kin">
+               <type>table</type>
+               <table_ref>kin</table_ref>
+            </table_grammar>
+         </table_grammar>
+      </message>
+      <message name="Message1">
+         <description></description>
+         <table_grammar name="Message1">
+            <type>group</type>
+         </table_grammar>
+      </message>
+   </global>
+   <config name="default">
+      <date_time name="DateTime">
+         <description>DTM DateTime</description>
+         <fields_required>False</fields_required>
+         <mask>YYYY</mask>
+         <mask>MM</mask>
+         <mask>DD</mask>
+         <mask>HH</mask>
+         <mask>mm</mask>
+         <mask>SS</mask>
+         <mask>.SSSS</mask>
+         <mask>+/-ZZZZ</mask>
+      </date_time>
+      <date_time name="Date">
+         <description>DT Date</description>
+         <fields_required>False</fields_required>
+         <mask>YYYY</mask>
+         <mask>MM</mask>
+         <mask>DD</mask>
+      </date_time>
+      <date_time name="Time">
+         <description>TM Time</description>
+         <fields_required>False</fields_required>
+         <mask>HH</mask>
+         <mask>mm</mask>
+         <mask>SS</mask>
+         <mask>.SSSS</mask>
+         <mask>+/-ZZZZ</mask>
+      </date_time>
+      <composite name="HD">
+         <description>Hierarchic Designator</description>
+         <field>
+            <name>Id</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>UniversalId</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UniversalIdType</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="ID">
+         <description>String Data</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="ST">
+         <description>String Data</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="IS">
+         <description>String Data</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="XCN">
+         <description>Extended Composite ID Number And Name For Persons</description>
+         <field>
+            <name>Id</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>FamilyName</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>FN</composite_ref>
+         </field>
+         <field>
+            <name>GivenName</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Initial</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Suffix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Prefix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Degree</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Source Table</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Name Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Identifier Check Digit</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Check Digit Scheme</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Identifier Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Facility</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Name Representation Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Name Context</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Name Validity Range</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Name Assembly Order</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Professional Suffix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Jurisdiction</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Agency Or Department</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </composite>
+      <composite name="CWE">
+         <description>Coded With Exceptions</description>
+         <field>
+            <name>Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name Of Coding System</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name Of Alternate Coding System</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Coding System Version ID</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Coding System Version ID</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Original Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="FN">
+         <description>Family Name</description>
+         <field>
+            <name>Surname</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Own Surname Prefix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Own Surname</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Surname Prefix From Partner/spouse</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Surname From Partner/spouse</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="TS">
+         <description>Time Stamp</description>
+         <field>
+            <name>Time</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Degree Of Precision</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="DTM">
+         <description>Date/Time</description>
+         <field>
+            <name>Value</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>DateTime</data_type>
+            <datetime_ref>DateTime</datetime_ref>
+         </field>
+      </composite>
+      <composite name="CE">
+         <description>Coded Element</description>
+         <field>
+            <name>Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name Of Coding System</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name Of Alternate Coding System</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="DR">
+         <description>Date/Time Range</description>
+         <field>
+            <name>Range Start Date/time</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Range End Date/time</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+      </composite>
+      <composite name="MSG">
+         <description>Message Type</description>
+         <field>
+            <name>Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Event</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>MessageStructure</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="EI">
+         <description>Entity Identifier</description>
+         <field>
+            <name>Entity Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Namespace ID</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Universal ID</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Universal ID Type</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="PT">
+         <description>Processing Type</description>
+         <field>
+            <name>Id</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Mode</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="VID">
+         <description>Version Identifier</description>
+         <field>
+            <name>Id</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>InternationalCode</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>International Version ID</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CE</composite_ref>
+         </field>
+      </composite>
+      <composite name="NM">
+         <description>Numeric</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Double</data_type>
+         </field>
+      </composite>
+      <composite name="XON">
+         <description>Extended Composite Name And Identification Number For Organizations</description>
+         <field>
+            <name>Organization Name</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Organization Name Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>ID Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Check Digit</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Check Digit Scheme</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Identifier Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Facility</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Name Representation Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Organization Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="XAD">
+         <description>Extended Address</description>
+         <field>
+            <name>Street</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>SAD</composite_ref>
+         </field>
+         <field>
+            <name>Other</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>City</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>State</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Zip</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Country</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Type</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Other</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>County</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Census</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Address Representation Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Address Validity Range</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+      </composite>
+      <composite name="SAD">
+         <description>Street Address</description>
+         <field>
+            <name>Steet</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>StreetName</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>DwellingNumber</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="DT">
+         <description>Date</description>
+         <field>
+            <name>Value</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>DateTime</data_type>
+            <datetime_ref>Date</datetime_ref>
+         </field>
+      </composite>
+      <composite name="SI">
+         <description>Sequence ID</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="XPN">
+         <description>Extended Person Name</description>
+         <field>
+            <name>Family Name</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>FN</composite_ref>
+         </field>
+         <field>
+            <name>Given Name</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Second And Further Given Names Or Initials Thereof</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Suffix (e.g., Jr Or III)</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Prefix (e.g., Dr)</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Degree (e.g., Md)</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Name Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Name Representation Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Name Context</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Name Validity Range</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Name Assembly Order</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Professional Suffix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="JCC">
+         <description>Job Code/Class</description>
+         <field>
+            <name>Job Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Job Class</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Job Description Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TX</composite_ref>
+         </field>
+      </composite>
+      <composite name="TX">
+         <description>Text Data</description>
+         <field>
+            <name>Value</name>
+            <max_length>0</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="CX">
+         <description>Extended Composite ID With Check Digit</description>
+         <field>
+            <name>ID Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Check Digit</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Check Digit Scheme</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Identifier Type Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Facility</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Jurisdiction</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Agency Or Department</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </composite>
+      <composite name="XTN">
+         <description>Extended Telecommunication Number</description>
+         <field>
+            <name>Telephone Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Telecommunication Use Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Telecommunication Equipment Type</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Email Address</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Country Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Area/city Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Local Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Extension</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Any Text</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Extension Prefix</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Speed Dial Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Unformatted Telephone Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="DLN">
+         <description>Driver&apos;s License Number</description>
+         <field>
+            <name>License Number</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Issuing State, Province, Country</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </composite>
+      <composite name="DLD">
+         <description>Discharge Location And Date</description>
+         <field>
+            <name>Discharge Location</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+      </composite>
+      <composite name="PL">
+         <description>Person Location</description>
+         <field>
+            <name>Point Of Care</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Room</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Bed</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Facility</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Location Status</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Person Location Type</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Building</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Floor</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Location Description</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Comprehensive Location Identifier</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority For Location</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+      </composite>
+      <composite name="FC">
+         <description>Financial Class</description>
+         <field>
+            <name>Financial Class Code</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TS</composite_ref>
+         </field>
+      </composite>
+      <composite name="ED">
+         <description>Encapsulated Data</description>
+         <field>
+            <name>Source Application</name>
+            <max_length>1027</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Type of Data</name>
+            <max_length>11</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Data Subtype</name>
+            <max_length>32</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Encoding</name>
+            <max_length>6</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Data</name>
+            <max_length>65536</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TX</composite_ref>
+         </field>
+      </composite>
+      <composite name="CNE">
+         <description>Coded with No Exceptions</description>
+         <field>
+            <name>Identifier</name>
+            <max_length>20</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Text</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name of Coding System</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Identifier</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Text</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Name of Alternate Coding System</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Coding System Version ID</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Coding System Version ID</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Original Text</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="CD">
+         <description>Channel Definition</description>
+         <field>
+            <name>Id</name>
+            <max_length>22</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>WVI</composite_ref>
+         </field>
+         <field>
+            <name>Waveform Source</name>
+            <max_length>17</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>WVS</composite_ref>
+         </field>
+         <field>
+            <name>Channel Sensitivity and Units</name>
+            <max_length>478</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CSU</composite_ref>
+         </field>
+         <field>
+            <name>Channel Calibration Parameters</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CCP</composite_ref>
+         </field>
+         <field>
+            <name>Channel Sampling Frequency</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Minimum and Maximum Data Values</name>
+            <max_length>33</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NR</composite_ref>
+         </field>
+      </composite>
+      <composite name="CCP">
+         <description>Channel Calibration Parameters</description>
+         <field>
+            <name>Channel Calibration Sensitivity Correction Factor</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Channel Calibration Baseline</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Channel Calibration Time Skew</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </composite>
+      <composite name="WVI">
+         <description>Channel Identifier</description>
+         <field>
+            <name>Num</name>
+            <max_length>4</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Name</name>
+            <max_length>17</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="CSU">
+         <description>Channel Sensitivity and Units</description>
+         <field>
+            <name>Channel Sensitivity</name>
+            <max_length>60</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Unit of Measure Identifier</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Unit of Measure Description</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Unit of Measure Coding System</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Unit of Measure Identifier</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Unit of Measure Description</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Unit of Measure Coding System</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="NR">
+         <description>Numeric Range</description>
+         <field>
+            <name>Low Value</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>High Value</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </composite>
+      <composite name="WVS">
+         <description>Waveform Source</description>
+         <field>
+            <name>Source One Name</name>
+            <max_length>8</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Source Two Name</name>
+            <max_length>8</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="CP">
+         <description>Composite Price</description>
+         <field>
+            <name>Price</name>
+            <max_length>20</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Price Type</name>
+            <max_length>2</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>From Value</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>To Value</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Range Units</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Range Type</name>
+            <max_length>1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="MO">
+         <description>Money</description>
+         <field>
+            <name>Quantity</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Denomination</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="AUI">
+         <description>Authorization Information</description>
+         <field>
+            <name>Authorization Number</name>
+            <max_length>30</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Date</name>
+            <max_length>8</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Source</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="PTA">
+         <description>Policy Type and Amount</description>
+         <field>
+            <name>Policy Type</name>
+            <max_length>5</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Amount Class</name>
+            <max_length>9</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Money or Percentage Quantity</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Money or Percentage</name>
+            <max_length>23</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MOP</composite_ref>
+         </field>
+      </composite>
+      <composite name="MOP">
+         <description>Money or Percentage</description>
+         <field>
+            <name>Money or Percentage Indicator</name>
+            <max_length>2</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Money or Percentage Quantity</name>
+            <max_length>16</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Currency Denomination</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="DDI">
+         <description>Daily Deductible Information</description>
+         <field>
+            <name>Delay Days</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Monetary Amount</name>
+            <max_length>16</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Number of Days</name>
+            <max_length>4</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </composite>
+      <composite name="RMC">
+         <description>Room Coverage</description>
+         <field>
+            <name>Room Type</name>
+            <max_length>20</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Amount Type</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Coverage Amount</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Money or Percentage</name>
+            <max_length>23</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MOP</composite_ref>
+         </field>
+      </composite>
+      <composite name="ICD">
+         <description>Insurance Certification Definition</description>
+         <field>
+            <name>Certification Patient Type</name>
+            <max_length>11</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Certification Required</name>
+            <max_length>1</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Date/Time Certification Required</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+      </composite>
+      <composite name="DTN">
+         <description>Day Type and Number</description>
+         <field>
+            <name>Day Type</name>
+            <max_length>2</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Number of Days</name>
+            <max_length>3</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </composite>
+      <composite name="OCD">
+         <description>Occurrence Code and Date</description>
+         <field>
+            <name>Occurrence Code</name>
+            <max_length>705</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Date</name>
+            <max_length>8</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </composite>
+      <composite name="UVC">
+         <description>UB Value Code and Amount</description>
+         <field>
+            <name>Value Code</name>
+            <max_length>20</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Value Amount</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MO</composite_ref>
+         </field>
+      </composite>
+      <composite name="OSP">
+         <description>Occurrence Span Code and Date</description>
+         <field>
+            <name>Occurrence Span Code</name>
+            <max_length>705</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Span Start Date</name>
+            <max_length>8</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Span Stop Date</name>
+            <max_length>8</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </composite>
+      <composite name="FT">
+         <description>Formatted Text Data</description>
+         <field>
+            <name>Value</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <composite name="TQ">
+         <description>Timing Quantity</description>
+         <field>
+            <name>Quantity</name>
+            <max_length>267</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Interval</name>
+            <max_length>206</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>RI</composite_ref>
+         </field>
+         <field>
+            <name>Duration</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Start Date/Time</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>End Date/Time</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Priority</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Condition</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Text</name>
+            <max_length>200</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TX</composite_ref>
+         </field>
+         <field>
+            <name>Conjunction</name>
+            <max_length>1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Order Sequencing</name>
+            <max_length>110</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>OSD</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Duration</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Total Occurrences</name>
+            <max_length>4</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </composite>
+      <composite name="RI">
+         <description>Repeat Interval</description>
+         <field>
+            <name>Repeat Pattern</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Explicit Time Interval</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="CQ">
+         <description>Composite Quantity with Units</description>
+         <field>
+            <name>Quantity</name>
+            <max_length>16</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Units</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </composite>
+      <composite name="OSD">
+         <description>Order Sequence Definition</description>
+         <field>
+            <name>Sequence/Results Flag</name>
+            <max_length>1</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number: Entity Identifier</name>
+            <max_length>15</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number: Namespace ID</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number: Entity Identifier</name>
+            <max_length>15</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number: Namespace ID</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Sequence Condition Value</name>
+            <max_length>12</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Maximum Number of Repeats</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number: Universal ID</name>
+            <max_length>15</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number: Universal ID Type</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number: Universal ID</name>
+            <max_length>15</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number: Universal ID Type</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="EIP">
+         <description>Entity Identifier Pair</description>
+         <field>
+            <name>Placer Assigned Identifier</name>
+            <max_length>427</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Filler Assigned Identifier</name>
+            <max_length>427</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>EI</composite_ref>
+         </field>
+      </composite>
+      <composite name="PRL">
+         <description>Parent Result Link</description>
+         <field>
+            <name>Parent Observation Identifier</name>
+            <max_length>705</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Parent Observation Sub-identifier</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Parent Observation Value Descriptor</name>
+            <max_length>250</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TX</composite_ref>
+         </field>
+      </composite>
+      <composite name="MOC">
+         <description>Money and Code</description>
+         <field>
+            <name>Monetary Amount</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Charge Code</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </composite>
+      <composite name="SPS">
+         <description>Specimen Source</description>
+         <field>
+            <name>Specimen Source Name or Code</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Additives</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Collection Method</name>
+            <max_length>200</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>TX</composite_ref>
+         </field>
+         <field>
+            <name>Body Site</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Site Modifier</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Collection Method Modifier Code</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Role</name>
+            <max_length>705</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </composite>
+      <composite name="NDL">
+         <description>Name with Date and Location</description>
+         <field>
+            <name>Name</name>
+            <max_length>406</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CNN</composite_ref>
+         </field>
+         <field>
+            <name>Start Date/time</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>End Date/time</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Point of Care</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Room</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Bed</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Facility</name>
+            <max_length>227</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Location Status</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Location Type</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Building</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Floor</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </composite>
+      <composite name="CNN">
+         <description>Composite ID Number and Name Simplified</description>
+         <field>
+            <name>ID Number</name>
+            <max_length>15</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Family Name</name>
+            <max_length>50</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Given Name</name>
+            <max_length>30</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Second and Further Given Names or Initials Thereof</name>
+            <max_length>30</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Suffix (e.g., JR or III)</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Prefix (e.g., DR)</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Degree (e.g., MD</name>
+            <max_length>5</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Source Table</name>
+            <max_length>4</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority   - Namespace ID</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority  - Universal ID</name>
+            <max_length>199</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Assigning Authority  - Universal ID Type</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </composite>
+      <composite name="LA1">
+         <description>Location with Address Variation 1</description>
+         <field>
+            <name>Point of Care</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Room</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Bed</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Facility</name>
+            <max_length>227</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Location Status</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Location Type</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Building</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Floor</name>
+            <max_length>20</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Address</name>
+            <max_length>415</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>AD</composite_ref>
+         </field>
+      </composite>
+      <composite name="AD">
+         <description>Address</description>
+         <field>
+            <name>Street Address</name>
+            <max_length>120</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Other Designation</name>
+            <max_length>120</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>City</name>
+            <max_length>50</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>State or Province</name>
+            <max_length>50</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Zip or Postal Code</name>
+            <max_length>12</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Country</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Address Type</name>
+            <max_length>3</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Other Geographic Designation</name>
+            <max_length>50</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </composite>
+      <composite name="PLN">
+         <description>Practitioner License or Other ID Number</description>
+         <field>
+            <name>ID Number</name>
+            <max_length>20</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Type of ID Number</name>
+            <max_length>8</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>State/other Qualifying Information</name>
+            <max_length>62</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_length>8</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </composite>
+      <composite name="CCD">
+         <description>Charge Code and Date</description>
+         <field>
+            <name>Invocation Event</name>
+            <max_length>1</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Date/time</name>
+            <max_length>24</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>DTM</composite_ref>
+         </field>
+      </composite>
+      <composite name="TM">
+         <description>Time</description>
+         <field>
+            <name>Value</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>DateTime</data_type>
+            <datetime_ref>Time</datetime_ref>
+         </field>
+      </composite>
+      <composite name="RPT">
+         <description>Repeat Pattern</description>
+         <field>
+            <name>Repeat Pattern Code</name>
+            <max_length>705</max_length>
+            <is_required>True</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Calendar Alignment</name>
+            <max_length>2</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Phase Range Begin Value</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Phase Range End Value</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Period Quantity</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Period Units</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Institution Specified Time</name>
+            <max_length>1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Event</name>
+            <max_length>6</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Event Offset Quantity</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Event Offset Units</name>
+            <max_length>10</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>General Timing Specification</name>
+            <max_length>200</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>Composite</data_type>
+            <composite_ref>GTS</composite_ref>
+         </field>
+      </composite>
+      <composite name="GTS">
+         <description>General Timing Specification</description>
+         <field>
+            <name>Value</name>
+            <max_length>-1</max_length>
+            <is_required>False</is_required>
+            <is_length_restricted>False</is_length_restricted>
+            <data_type>String</data_type>
+         </field>
+      </composite>
+      <segment id="0">
+         <name>EVN</name>
+         <description>Event Type</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Event Type Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Recorded Date/time2</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Date/time Planned Event</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Event Reason Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Operator ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Event Occurred</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Event Facility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+      </segment>
+      <segment id="1">
+         <name>MSH</name>
+         <description>Message Header</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>FieldSep1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>EncodingChars</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>SendingApplication</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>SendingFacility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>ReceivingApplication</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>ReceivingFacility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>TimeStamp</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Security</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MSG</composite_ref>
+         </field>
+         <field>
+            <name>MessageControlID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>ProcessingId</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PT</composite_ref>
+         </field>
+         <field>
+            <name>Version</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>VID</composite_ref>
+         </field>
+         <field>
+            <name>SequenceNum</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Continuation Pointer</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Accept Acknowledgment Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Application Acknowledgment Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Country Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>CharSet</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Principal Language Of Message</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Character Set Handling Scheme</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Message Profile Identifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+      </segment>
+      <segment id="2">
+         <name>NK1</name>
+         <description>Next Of Kin / Associated Parties</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>SetId</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Relationship</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Phone</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>BusinessPhone</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>ContactRole</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>End Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Next Of Kin / Associated Parties Job Title</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Next Of Kin / Associated Parties Job Code/class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>JCC</composite_ref>
+         </field>
+         <field>
+            <name>Next Of Kin / Associated Parties Employee Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Organization Name - Nk1</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Marital Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Sex</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Dob</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Living Dependency</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Ambulatory Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Primary Language</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Living Arrangement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Student Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Religion</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Mother&apos;s Maiden Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Nationality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Ethnic Group</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Reason</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Telephone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Next Of Kin/associated Party&apos;s Identifiers</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Job Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Race</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Handicap</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person Social Security Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Next Of Kin Birth Place</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Vip Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="3">
+         <name>PID</name>
+         <description>Patient Identification</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>SetId</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Id</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>IdList</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>AlternateId</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>MaidenName</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Dob</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Sex</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Alias</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Race</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>CountyCode</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>HomePhone</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>BusinessPhone</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Language</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>MaritalStatus</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Religion</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>AccountNumber</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>SSN</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>DriverLicense</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DLN</composite_ref>
+         </field>
+         <field>
+            <name>MotherId</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Ethnicity</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>BirthPlace</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Multiple Birth Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>BirthOrder</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>VeteranMilitartyStatus</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Nationality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>DeathTimestamp</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Death Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Identity Unknown Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Identity Reliability Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Last Update Date/time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Last Update Facility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>HD</composite_ref>
+         </field>
+         <field>
+            <name>Species Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Breed Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Strain</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Production Class Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Tribal Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="4">
+         <name>PV1</name>
+         <description>Patient Visit</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - Pv1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Patient Class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Assigned Patient Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Admission Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Preadmit Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Prior Patient Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Attending Doctor</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Referring Doctor</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Consulting Doctor</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Hospital Service</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Temporary Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Preadmit Test Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Re-admission Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Admit Source</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Ambulatory Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Vip Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Admitting Doctor</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Patient Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Visit Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Financial Class</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>FC</composite_ref>
+         </field>
+         <field>
+            <name>Charge Price Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Courtesy Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Credit Rating</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Contract Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Contract Effective Date</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Contract Amount</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Contract Period</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Interest Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Transfer To Bad Debt Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Transfer To Bad Debt Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Bad Debt Agency Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Bad Debt Transfer Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Bad Debt Recovery Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Delete Account Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Delete Account Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Discharge Disposition</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Discharged To Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DLD</composite_ref>
+         </field>
+         <field>
+            <name>Diet Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CE</composite_ref>
+         </field>
+         <field>
+            <name>Servicing Facility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Bed Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Account Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Pending Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Prior Temporary Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Admit Date/time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Discharge Date/time</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TS</composite_ref>
+         </field>
+         <field>
+            <name>Current Patient Balance</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Total Charges</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Total Adjustments</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Total Payments</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Alternate Visit ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Visit Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Other Healthcare Provider</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+      </segment>
+      <segment id="5">
+         <name>SFT</name>
+         <description>Software Segment</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Software Vendor Organization</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>567</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Software Certified Version or Release Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Software Product Name</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Software Binary ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Software Product Information</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1024</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TX</composite_ref>
+         </field>
+         <field>
+            <name>Software Install Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+      </segment>
+      <segment id="6">
+         <name>UAC</name>
+         <description>User Authentication Credential Segment</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>User Authentication Credential Type Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>User Authentication Credential</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>65536</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ED</composite_ref>
+         </field>
+      </segment>
+      <segment id="7">
+         <name>PD1</name>
+         <description>Patient Additional Demographic</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Living Dependency</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Living Arrangement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Primary Facility</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Patient Primary Care Provider Name &amp; ID No.</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Student Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Handicap</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Living Will Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Organ Donor Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Separate Bill</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Duplicate Patient</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Place of Worship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Advance Directive Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Immunization Registry Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Immunization Registry Status Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Military Branch</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Military Rank/Grade</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Military Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Advance Directive Last Verified Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </segment>
+      <segment id="8">
+         <name>ARV</name>
+         <description>Access Restriction</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Access Restriction Action Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Access Restriction Value</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Access Restriction Reason</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Special Access Restriction Instructions</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Access Restriction Date Range</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>49</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DR</composite_ref>
+         </field>
+      </segment>
+      <segment id="9">
+         <name>ROL</name>
+         <description>Role</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Role Instance ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Action Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Role-ROL</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Role Person</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Role Begin Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Role End Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Role Duration</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Role Action Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Provider Type</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Organization Unit Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Office/Home Address/Birthplace</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Phone</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Person&apos;s Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1230</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+      </segment>
+      <segment id="10">
+         <name>NK1</name>
+         <description>Next of Kin / Associated Parties</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - NK1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Relationship</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Business Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Role</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>End Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Next of Kin / Associated Parties Job Title</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Next of Kin / Associated Parties Job Code/Class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>JCC</composite_ref>
+         </field>
+         <field>
+            <name>Next of Kin / Associated Parties Employee Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Organization Name - NK1</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Marital Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Administrative Sex</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Date/Time of Birth</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Living Dependency</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Ambulatory Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Primary Language</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Living Arrangement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Student Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Religion</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Mother&apos;s Maiden Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Nationality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Ethnic Group</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Reason</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Telephone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Next of Kin/Associated Party&apos;s Identifiers</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Job Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Race</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Handicap</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person Social Security Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>16</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Next of Kin Birth Place</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>VIP Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="11">
+         <name>PV2</name>
+         <description>Patient Visit - Additional Information</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Prior Pending Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Accommodation Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Admit Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Transfer Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Patient Valuables</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Patient Valuables Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Visit User Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Expected Admit Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Expected Discharge Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Estimated Length of Inpatient Stay</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Actual Length of Inpatient Stay</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Visit Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>50</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Referral Source Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Previous Service Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Employment Illness Related Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Purge Status Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Purge Status Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Special Program Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Retention Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Expected Number of Insurance Plans</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Visit Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Visit Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Clinic Organization Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Patient Status Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Visit Priority Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Previous Treatment Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Expected Discharge Disposition</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Signature on File Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>First Similar Illness Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Patient Charge Adjustment Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Recurring Service Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Billing Media Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Expected Surgery Date and Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Military Partnership Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Military Non-Availability Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Newborn Baby Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Baby Detained Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Mode of Arrival Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Recreational Drug Use Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Admission Level of Care Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Precaution Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Patient Condition Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Living Will Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Organ Donor Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Advance Directive Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Patient Status Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Expected LOA Return Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Expected Pre-admission Testing Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Notify Clergy Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Advance Directive Last Verified Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </segment>
+      <segment id="12">
+         <name>DB1</name>
+         <description>Disability</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - DB1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Disabled Person Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Disabled Person Identifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Disability Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Disability Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Disability End Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Disability Return to Work Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Disability Unable to Work Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </segment>
+      <segment id="13">
+         <name>OBX</name>
+         <description>Observation/Result</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - OBX</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Value Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Sub-Id</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Value</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>581</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CD</composite_ref>
+         </field>
+         <field>
+            <name>Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>References Range</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Abnormal Flags</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Probability</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Nature of Abnormal Test</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Observation Result Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Effective Date of Reference Range</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>User Defined Access Checks</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Date/Time of the Observation</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Producer&apos;s ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Responsible Observer</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Observation Method</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Equipment Instance Identifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Date/Time of the Analysis</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Observation Site</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Observation Instance Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Mood Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Performing Organization Name</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>570</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Performing Organization Address</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2915</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Performing Organization Medical Director</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+      </segment>
+      <segment id="14">
+         <name>AL1</name>
+         <description>Patient Allergy Information</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - AL1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Allergen Type Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Allergen Code/Mnemonic/Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Allergy Severity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Allergy Reaction Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Identification Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </segment>
+      <segment id="15">
+         <name>DG1</name>
+         <description>Diagnosis</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - DG1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Coding Method</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Code - DG1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Major Diagnostic Category</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Diagnostic Related Group</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>DRG Approval Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>DRG Grouper Review Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Cost</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Grouper Version And Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Priority</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosing Clinician</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Classification</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Confidential Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Attestation Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Action Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Parent Diagnosis</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>DRG CCL Value Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>DRG Grouping Usage</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>DRG Diagnosis Determination Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Present On Admission (POA) Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="16">
+         <name>DRG</name>
+         <description>Diagnosis Related Group</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Diagnostic Related Group</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>DRG Assigned Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>DRG Approval Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>DRG Grouper Review Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Cost</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>DRG Payor</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Outlier Reimbursement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>9</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Confidential Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>DRG Transfer Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>21</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Name of Coder</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1103</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Grouper Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>PCCL Value Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Effective Weight</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Monetary Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Status Patient</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Grouper Software Name</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>100</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Grouper Software Version</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>100</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Status Financial Calculation</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Relative Discount/Surcharge</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Basic Charge</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Total Charge</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Discount/Surcharge</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MO</composite_ref>
+         </field>
+         <field>
+            <name>Calculated Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Status Gender</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Age</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Length of Stay</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Same Day Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Separation Mode</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Weight at Birth</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Respiration Minutes</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Status Admission</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="17">
+         <name>PR1</name>
+         <description>Procedures</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - PR1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Coding Method</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Functional Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Minutes</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Anesthesiologist</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Anesthesia Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Anesthesia Minutes</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Surgeon</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Practitioner</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Consent Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Priority</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Associated Diagnosis Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code Modifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure DRG Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Tissue Type Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Action Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>DRG Procedure Determination Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>DRG Procedure Relevance</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="18">
+         <name>GT1</name>
+         <description>Guarantor</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - GT1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Spouse Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Ph Num - Home</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Ph Num - Business</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Date/Time Of Birth</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Administrative Sex</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Relationship</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor SSN</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>11</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Date - Begin</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Date - End</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Priority</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employer Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employer Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employer Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employee ID Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employment Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Organization Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Billing Hold Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Credit Rating Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Death Date And Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Death Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Charge Adjustment Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Household Annual Income</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Household Size</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employer ID Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Marital Status Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Hire Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Employment Stop Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Living Dependency</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Ambulatory Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Primary Language</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Living Arrangement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Student Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Religion</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Mother&apos;s Maiden Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Nationality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Ethnic Group</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Person&apos;s Telephone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Relationship</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Job Title</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Job Code/Class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>JCC</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Employer&apos;s Organization Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Handicap</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Job Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Financial Class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>50</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>FC</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Race</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor Birth Place</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>VIP Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="19">
+         <name>IN1</name>
+         <description>Insurance</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - IN1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Plan ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Company ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Company Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Company Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Co Contact Person</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Co Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Group Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Group Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Group Emp ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Group Emp Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Plan Effective Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Plan Expiration Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Authorization Information</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>239</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>AUI</composite_ref>
+         </field>
+         <field>
+            <name>Plan Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Name Of Insured</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Relationship To Patient</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Date Of Birth</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Assignment Of Benefits</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Coordination Of Benefits</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Coord Of Ben. Priority</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Notice Of Admission Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Notice Of Admission Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Report Of Eligibility Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Report Of Eligibility Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Release Information Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Pre-Admit Cert (PAC)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Verification Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Verification By</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Type Of Agreement Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Billing Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Lifetime Reserve Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Delay Before L.R. Day</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Company Plan Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Policy Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Policy Deductible</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Policy Limit - Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Policy Limit - Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Room Rate - Semi-Private</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Room Rate - Private</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Employment Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Administrative Sex</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Employer&apos;s Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Verification Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Prior Insurance Plan ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Coverage Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Handicap</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s ID Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Signature Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Signature Code Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Birth Place</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>VIP Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+      </segment>
+      <segment id="20">
+         <name>IN2</name>
+         <description>Insurance Additional Information</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Insured&apos;s Employee ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Social Security Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>11</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Employer&apos;s Name and ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Employer Information Data</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Mail Claim Party</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Medicare Health Ins Card Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Medicaid Case Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Medicaid Case Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>15</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Military Sponsor Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Military ID Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Dependent Of Military Recipient</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Military Organization</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Military Station</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Military Service</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>14</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Military Rank/Grade</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Military Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Military Retire Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Military Non-Avail Cert On File</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Baby Coverage</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Combine Baby Bill</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Blood Deductible</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Special Coverage Approval Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Special Coverage Approval Title</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>30</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Non-Covered Insurance Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Payor ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Payor Subscriber ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Eligibility Source</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Room Coverage Type/Amount</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>82</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>RMC</composite_ref>
+         </field>
+         <field>
+            <name>Policy Type/Amount</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>56</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PTA</composite_ref>
+         </field>
+         <field>
+            <name>Daily Deductible</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DDI</composite_ref>
+         </field>
+         <field>
+            <name>Living Dependency</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Ambulatory Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Citizenship</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Primary Language</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Living Arrangement</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Publicity Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Protection Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Student Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Religion</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Mother&apos;s Maiden Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Nationality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Ethnic Group</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Marital Status</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Employment Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Employment Stop Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Job Title</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Job Code/Class</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>JCC</composite_ref>
+         </field>
+         <field>
+            <name>Job Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Employer Contact Person Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Employer Contact Person Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Employer Contact Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Contact Person&apos;s Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Contact Person Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Contact Person Reason</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Relationship to the Patient Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Relationship to the Patient Stop Date</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Co Contact Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Co Contact Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Policy Scope</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Policy Source</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Member Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Guarantor&apos;s Relationship to Insured</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Phone Number - Home</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Insured&apos;s Employer Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Military Handicapped Program</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Suspend Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Copay Limit Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Stoploss Limit Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Insured Organization Name and ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Insured Employer Organization Name and ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Race</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Patient&apos;s Relationship to Insured</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="21">
+         <name>IN3</name>
+         <description>Insurance Additional Information, Certification</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - IN3</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Certification Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Certified By</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Certification Required</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Penalty</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>23</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MOP</composite_ref>
+         </field>
+         <field>
+            <name>Certification Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Certification Modify Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Operator</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Certification Begin Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Certification End Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>6</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTN</composite_ref>
+         </field>
+         <field>
+            <name>Non-Concur Code/Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Non-Concur Effective Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Physician Reviewer</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Certification Contact</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>48</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Certification Contact Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Appeal Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Certification Agency</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Certification Agency Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Pre-Certification Requirement</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>40</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ICD</composite_ref>
+         </field>
+         <field>
+            <name>Case Manager</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>48</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Second Opinion Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Second Opinion Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Second Opinion Documentation Received</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Second Opinion Physician</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+      </segment>
+      <segment id="22">
+         <name>ACC</name>
+         <description>Accident</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Accident Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Accident Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Accident Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Auto Accident State</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Accident Job Related Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Accident Death Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Entered By</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Accident Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>25</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Brought In By</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Police Notified Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Accident Address</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+      </segment>
+      <segment id="23">
+         <name>UB1</name>
+         <description>UB82</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - UB1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Blood Deductible</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Blood Furnished-Pints</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Blood Replaced-Pints</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Blood Not Replaced-Pints</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Co-Insurance Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Condition Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Covered Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Non Covered Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Value Amount &amp; Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>UVC</composite_ref>
+         </field>
+         <field>
+            <name>Number Of Grace Days</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Special Program Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>PSRO/UR Approval Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>PSRO/UR Approved Stay-Fm</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>PSRO/UR Approved Stay-To</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>OCD</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Span</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Occur Span Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>Occur Span End Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+         <field>
+            <name>UB-82 Locator 2</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB-82 Locator 9</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB-82 Locator 27</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB-82 Locator 45</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </segment>
+      <segment id="24">
+         <name>UB2</name>
+         <description>UB92 Data</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - UB2</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Co-Insurance Days (9)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Condition Code (24-30)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Covered Days (7)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Non-Covered Days (8)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Value Amount &amp; Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>41</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>UVC</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Code &amp; Date (32-35)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>259</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>OCD</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence Span Code/Dates (36)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>268</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>OSP</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 2 (State)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>29</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 11 (State)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 31 (National)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Document Control Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>23</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 49 (National)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 56 (State)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>14</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 57 (National)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>27</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>UB92 Locator 78 (State)</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Special Visit Count</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </segment>
+      <segment id="25">
+         <name>PDA</name>
+         <description>Patient Death and Autopsy</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Death Cause Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Death Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Death Certified Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Death Certificate Signed Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Death Certified By</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Autopsy Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Autopsy Start and End Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>53</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Autopsy Performed By</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Coroner Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </segment>
+      <segment id="26">
+         <name>NTE</name>
+         <description>Notes and Comments</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - NTE</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Source of Comment</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Comment</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>65536</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>FT</composite_ref>
+         </field>
+         <field>
+            <name>Comment Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Entered By</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Entered Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Effective Start Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Expiration Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+      </segment>
+      <segment id="27">
+         <name>ORC</name>
+         <description>Common Order</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Order Control</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Placer Group Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>22</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Order Status</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Response Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Quantity/Timing</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TQ</composite_ref>
+         </field>
+         <field>
+            <name>Parent</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>200</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EIP</composite_ref>
+         </field>
+         <field>
+            <name>Date/Time of Transaction</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Entered By</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Verified By</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Provider</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Enterer&apos;s Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Call Back Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Order Effective Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Order Control Code Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Entering Organization</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Entering Device</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Action By</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Advanced Beneficiary Notice Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Facility Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XON</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Facility Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Facility Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Provider Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Order Status Modifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Advanced Beneficiary Notice Override Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Filler&apos;s Expected Availability Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Confidentiality Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Order Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Enterer Authorization Mode</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Parent Universal Service Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="28">
+         <name>OBR</name>
+         <description>Observation Request</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - OBR</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Placer Order Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Universal Service Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Priority</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Requested Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Observation Date/Time #</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Observation End Date/Time #</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Collection Volume *</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>722</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Collector Identifier *</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Action Code *</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Danger Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Relevant Clinical Information</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>300</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Received Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Source</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SPS</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Provider</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Order Callback Phone Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2743</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Placer Field 1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>199</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Placer Field 2</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>199</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Filler Field 1 +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>199</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Filler Field 2 +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>199</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Results Rpt/Status Chng - Date/Time +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Charge to Practice +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>504</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>MOC</composite_ref>
+         </field>
+         <field>
+            <name>Diagnostic Serv Sect ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Result Status +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Parent Result +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>977</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PRL</composite_ref>
+         </field>
+         <field>
+            <name>Quantity/Timing</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TQ</composite_ref>
+         </field>
+         <field>
+            <name>Result Copies To</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>3220</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Parent</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>855</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EIP</composite_ref>
+         </field>
+         <field>
+            <name>Transportation Mode</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Reason for Study</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Principal Result Interpreter +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NDL</composite_ref>
+         </field>
+         <field>
+            <name>Assistant Result Interpreter +</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NDL</composite_ref>
+         </field>
+         <field>
+            <name>Technician +</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NDL</composite_ref>
+         </field>
+         <field>
+            <name>Transcriptionist +</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NDL</composite_ref>
+         </field>
+         <field>
+            <name>Scheduled Date/Time +</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Number of Sample Containers *</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>16</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Transport Logistics of Collected Sample *</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Collector&apos;s Comment *</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Transport Arrangement Responsibility</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Transport Arranged</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>30</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Escort Required</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Planned Patient Transport Comment</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code Modifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Placer Supplemental Service Information</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Filler Supplemental Service Information</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Medically Necessary Duplicate Procedure Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Result Handling</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Parent Universal Service Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="29">
+         <name>RQD</name>
+         <description>Requisition Detail</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Requisition Line Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Item Code - Internal</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Item Code - External</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Hospital Item Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requisition Quantity</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>6</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requisition Unit of Measure</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Cost Center Account Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>30</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Item Natural Account Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>30</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Deliver To ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Date Needed</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DT</composite_ref>
+         </field>
+      </segment>
+      <segment id="30">
+         <name>RQ1</name>
+         <description>Requisition Detail-1</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Anticipated Price</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Manufacturer Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Manufacturer&apos;s Catalog</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>16</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Vendor ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Vendor Catalog</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>16</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Taxable</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Substitute Allowed</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </segment>
+      <segment id="31">
+         <name>RXO</name>
+         <description>Pharmacy/Treatment Order</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Requested Give Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Amount - Minimum</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Amount - Maximum</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requested Dosage Form</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Provider&apos;s Pharmacy/Treatment Instructions</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Provider&apos;s Administration Instructions</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Deliver-To Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>LA1</composite_ref>
+         </field>
+         <field>
+            <name>Allow Substitutions</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Requested Dispense Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requested Dispense Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requested Dispense Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Number Of Refills</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>3</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Ordering Provider&apos;s DEA Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Pharmacist/Treatment Supplier&apos;s Verifier ID</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Needs Human Review</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Per (Time Unit)</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Strength</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Strength Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Indication</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Rate Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>6</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Requested Give Rate Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Total Daily Dose</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Supplementary Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Requested Drug Strength Volume</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>5</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Requested Drug Strength Volume Units</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Pharmacy Order Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Dispensing Interval</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Medication Instance Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Segment Instance Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Mood Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Dispensing Pharmacy</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Dispensing Pharmacy Address</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Deliver-to Patient Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Deliver-to Address</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+      </segment>
+      <segment id="32">
+         <name>ODS</name>
+         <description>Dietary Orders, Supplements, and Preferences</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Service Period</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Diet, Supplement, or Preference Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Text Instruction</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </segment>
+      <segment id="33">
+         <name>ODT</name>
+         <description>Diet Tray Instructions</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Tray Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Service Period</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Text Instruction</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+      </segment>
+      <segment id="34">
+         <name>CTD</name>
+         <description>Contact Data</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Contact Role</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Name</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XPN</composite_ref>
+         </field>
+         <field>
+            <name>Contact Address</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>2915</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XAD</composite_ref>
+         </field>
+         <field>
+            <name>Contact Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Contact Communication Information</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XTN</composite_ref>
+         </field>
+         <field>
+            <name>Preferred Method of Contact</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Contact Identifiers</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>100</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PLN</composite_ref>
+         </field>
+      </segment>
+      <segment id="35">
+         <name>FT1</name>
+         <description>Financial Transaction</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - FT1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Transaction ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Batch ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>53</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Posting Date</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>8</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Description</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Description - Alt</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>0</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Quantity</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>6</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Amount - Extended</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Transaction amount - unit</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Department Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Plan ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Insurance Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Assigned Patient Location</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>80</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>PL</composite_ref>
+         </field>
+         <field>
+            <name>Fee Schedule</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Patient Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>IS</composite_ref>
+         </field>
+         <field>
+            <name>Diagnosis Code - FT1</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Performed By Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Ordered By Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Unit Cost</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>12</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CP</composite_ref>
+         </field>
+         <field>
+            <name>Filler Order Number</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Entered By Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>XCN</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Procedure Code Modifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CNE</composite_ref>
+         </field>
+         <field>
+            <name>Advanced Beneficiary Notice Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Medically Necessary Duplicate Procedure Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>NDC Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Payment Reference ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Transaction Reference Key</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+      </segment>
+      <segment id="36">
+         <name>CTI</name>
+         <description>Clinical Trial Identification</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Sponsor Study ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>427</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Study Phase Identifier</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Study Scheduled Time Point</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="37">
+         <name>BLG</name>
+         <description>Billing</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>When to Charge</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>40</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CCD</composite_ref>
+         </field>
+         <field>
+            <name>Charge Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>50</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Account ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>100</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CX</composite_ref>
+         </field>
+         <field>
+            <name>Charge Type Reason</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>60</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="38">
+         <name>TQ1</name>
+         <description>Timing/Quantity</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - TQ1</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Quantity</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Repeat Pattern</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>540</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>RPT</composite_ref>
+         </field>
+         <field>
+            <name>Explicit Time</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TM</composite_ref>
+         </field>
+         <field>
+            <name>Relative Time and Units</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Service Duration</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Start date/time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>End date/time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Priority</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Condition text</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TX</composite_ref>
+         </field>
+         <field>
+            <name>Text instruction</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>TX</composite_ref>
+         </field>
+         <field>
+            <name>Conjunction</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Occurrence duration</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Total occurrences</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+      </segment>
+      <segment id="39">
+         <name>TQ2</name>
+         <description>Timing/Quantity Relationship</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - TQ2</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Sequence/Results Flag</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Related Placer Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>22</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Related Filler Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>22</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Related Placer Group Number</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>22</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EI</composite_ref>
+         </field>
+         <field>
+            <name>Sequence Condition Code</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>2</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Cyclic Entry/Exit Indicator</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Sequence Condition Time Interval</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Cyclic Group Maximum Number of Repeats</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>10</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Special Service Request Relationship</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </segment>
+      <segment id="40">
+         <name>SPM</name>
+         <description>Specimen</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Set ID - SPM</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>SI</composite_ref>
+         </field>
+         <field>
+            <name>Specimen ID</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>855</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EIP</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Parent IDs</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>855</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>EIP</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>True</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Type Modifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Additives</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Collection Method</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Source Site</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Source Site Modifier</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Collection Site</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Role</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Collection Amount</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>20</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Grouped Specimen Count</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>6</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Description</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>250</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Handling Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Risk Code</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Collection Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>49</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DR</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Received Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Expiration Date/Time</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>24</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>DTM</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Availability</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Reject Reason</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Quality</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Appropriateness</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Condition</name>
+            <max_repeats>-1</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Current Quantity</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>722</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CQ</composite_ref>
+         </field>
+         <field>
+            <name>Number of Specimen Containers</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>4</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>NM</composite_ref>
+         </field>
+         <field>
+            <name>Container Type</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Container Condition</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+         <field>
+            <name>Specimen Child Role</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>705</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>CWE</composite_ref>
+         </field>
+      </segment>
+      <segment id="41">
+         <name>DSC</name>
+         <description>Continuation Pointer</description>
+         <has_delimiters>True</has_delimiters>
+         <field>
+            <name>Continuation Pointer</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>180</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ST</composite_ref>
+         </field>
+         <field>
+            <name>Continuation Style</name>
+            <max_repeats>0</max_repeats>
+            <is_required>False</is_required>
+            <width>1</width>
+            <in_equation><![CDATA[]]></in_equation>
+            <out_equation><![CDATA[]]></out_equation>
+            <composite_ref>ID</composite_ref>
+         </field>
+      </segment>
+      <segment id="42">
+         <name>CT1</name>
+         <description></description>
+         <has_delimiters>True</has_delimiters>
+      </segment>
+      <match msg="ADT">
+      </match>
+      <match msg="Lab">
+      </match>
+      <match msg="Message1">
+      </match>
+      <match msg="Catchall">
+      </match>
+      <table name="patient">
+         <config_mapset name="default">
+            <mapset name="Mapset">
+               <node_address>
+                  <pair>
+                     <node_index>2</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>4</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>4</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>1</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>9</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>12</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>13</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>16</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>15</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>18</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>19</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+            </mapset>
+         </config_mapset>
+         <column name="Id">
+            <config name="default">
+               <is_key>True</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="LastName">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="GivenName">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Race">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="PhoneHome">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="PhoneBusiness">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Religion">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="MaritalStatus">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Ssn">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="LicenseNumber">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Dob">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Sex">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Weight">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+      </table>
+      <table name="kin">
+         <config_mapset name="default">
+            <mapset name="Mapset">
+               <node_address>
+                  <pair>
+                     <node_index>2</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>1</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>0</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+                  <pair>
+                     <node_index>1</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+                  <pair>
+                     <node_index>1</node_index>
+                     <repeat_index>0</repeat_index>
+                  </pair>
+               </node_address>
+               <node_address>
+               </node_address>
+            </mapset>
+         </config_mapset>
+         <column name="PatientId">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="LastName">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="FirstName">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="Relationship">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+      </table>
+      <table name="visitinformation">
+         <config_mapset name="default">
+            <mapset name="Mapset">
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+               <node_address>
+               </node_address>
+            </mapset>
+         </config_mapset>
+         <column name="PatientClass">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="AdmitType">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="AdmitSource">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="HospitalService">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+         <column name="PatientType">
+            <config name="default">
+               <is_key>False</is_key>
+               <in_equation><![CDATA[]]></in_equation>
+               <out_equation><![CDATA[]]></out_equation>
+            </config>
+         </column>
+      </table>
+      <message name="ADT">
+         <ignore_unknown_segments>True</ignore_unknown_segments>
+         <ignore_segment_order>False</ignore_segment_order>
+         <in_equation><![CDATA[]]></in_equation>
+         <out_equation><![CDATA[]]></out_equation>
+         <message_grammar id="0">
+            <name>Message</name>
+            <is_optional>False</is_optional>
+            <is_repeating>False</is_repeating>
+            <ignore_segment_order>False</ignore_segment_order>
+            <max_repeats>0</max_repeats>
+            <type>group</type>
+            <message_grammar id="1">
+               <name>MSH</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>1</segment_ref>
+            </message_grammar>
+            <message_grammar id="2">
+               <name>EVN</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>0</segment_ref>
+            </message_grammar>
+            <message_grammar id="3">
+               <name>PID</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>3</segment_ref>
+            </message_grammar>
+            <message_grammar id="4">
+               <name>PD1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>7</segment_ref>
+            </message_grammar>
+            <message_grammar id="5">
+               <name>NK1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>10</segment_ref>
+            </message_grammar>
+            <message_grammar id="6">
+               <name>PV1</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>4</segment_ref>
+            </message_grammar>
+            <message_grammar id="7">
+               <name>PV2</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>11</segment_ref>
+            </message_grammar>
+            <message_grammar id="8">
+               <name>OBX</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>13</segment_ref>
+            </message_grammar>
+            <message_grammar id="9">
+               <name>AL1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>14</segment_ref>
+            </message_grammar>
+            <message_grammar id="10">
+               <name>DG1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>15</segment_ref>
+            </message_grammar>
+            <message_grammar id="11">
+               <name>DRG</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>16</segment_ref>
+            </message_grammar>
+            <message_grammar id="12">
+               <name>PROCEDURE</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>group</type>
+               <message_grammar id="13">
+                  <name>PR1</name>
+                  <is_optional>False</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>17</segment_ref>
+               </message_grammar>
+               <message_grammar id="14">
+                  <name>ROL</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>9</segment_ref>
+               </message_grammar>
+            </message_grammar>
+            <message_grammar id="15">
+               <name>GT1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>18</segment_ref>
+            </message_grammar>
+            <message_grammar id="16">
+               <name>INSURANCE</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>group</type>
+               <message_grammar id="17">
+                  <name>IN1</name>
+                  <is_optional>False</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>19</segment_ref>
+               </message_grammar>
+               <message_grammar id="18">
+                  <name>IN2</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>20</segment_ref>
+               </message_grammar>
+               <message_grammar id="19">
+                  <name>IN3</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>21</segment_ref>
+               </message_grammar>
+               <message_grammar id="20">
+                  <name>ROL</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>9</segment_ref>
+               </message_grammar>
+            </message_grammar>
+            <message_grammar id="21">
+               <name>ACC</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>22</segment_ref>
+            </message_grammar>
+            <message_grammar id="22">
+               <name>UB1</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>23</segment_ref>
+            </message_grammar>
+            <message_grammar id="23">
+               <name>UB2</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>24</segment_ref>
+            </message_grammar>
+            <message_grammar id="24">
+               <name>PDA</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>25</segment_ref>
+            </message_grammar>
+         </message_grammar>
+         <identifier>
+            <segment_ref>MSH</segment_ref>
+            <value>ADT</value>
+            <node_address>
+               <pair>
+                  <node_index>8</node_index>
+                  <repeat_index>0</repeat_index>
+               </pair>
+               <pair>
+                  <node_index>0</node_index>
+                  <repeat_index>0</repeat_index>
+               </pair>
+            </node_address>
+         </identifier>
+         <table_grammar name="ADT">
+            <type>group</type>
+            <grammar_field_index>-1</grammar_field_index>
+            <grammar_root_ref>0</grammar_root_ref>
+            <table_grammar name="patient">
+               <type>table</type>
+               <grammar_field_index>-1</grammar_field_index>
+               <mapset_ref>Mapset</mapset_ref>
+            </table_grammar>
+            <table_grammar name="kin">
+               <type>table</type>
+               <grammar_field_index>-1</grammar_field_index>
+               <mapset_ref>Mapset</mapset_ref>
+            </table_grammar>
+            <table_grammar name="visitinformation">
+               <type>table</type>
+               <grammar_field_index>-1</grammar_field_index>
+               <mapset_ref>Mapset</mapset_ref>
+            </table_grammar>
+         </table_grammar>
+      </message>
+      <message name="Catchall">
+         <ignore_unknown_segments>True</ignore_unknown_segments>
+         <ignore_segment_order>False</ignore_segment_order>
+         <in_equation><![CDATA[]]></in_equation>
+         <out_equation><![CDATA[]]></out_equation>
+         <message_grammar id="0">
+            <name>Message</name>
+            <is_optional>False</is_optional>
+            <is_repeating>False</is_repeating>
+            <ignore_segment_order>False</ignore_segment_order>
+            <max_repeats>0</max_repeats>
+            <type>group</type>
+            <message_grammar id="1">
+               <name>MSH</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>1</segment_ref>
+            </message_grammar>
+         </message_grammar>
+         <table_grammar name="Catchall">
+            <type>group</type>
+            <grammar_field_index>-1</grammar_field_index>
+            <grammar_root_ref>0</grammar_root_ref>
+         </table_grammar>
+      </message>
+      <message name="Lab">
+         <ignore_unknown_segments>True</ignore_unknown_segments>
+         <ignore_segment_order>False</ignore_segment_order>
+         <in_equation><![CDATA[]]></in_equation>
+         <out_equation><![CDATA[]]></out_equation>
+         <message_grammar id="0">
+            <name>Message</name>
+            <is_optional>False</is_optional>
+            <is_repeating>False</is_repeating>
+            <ignore_segment_order>False</ignore_segment_order>
+            <max_repeats>0</max_repeats>
+            <type>group</type>
+            <message_grammar id="1">
+               <name>MSH</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>1</segment_ref>
+            </message_grammar>
+            <message_grammar id="2">
+               <name>NTE</name>
+               <is_optional>True</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>26</segment_ref>
+            </message_grammar>
+            <message_grammar id="3">
+               <name>PATIENT</name>
+               <is_optional>True</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>group</type>
+               <message_grammar id="4">
+                  <name>PID</name>
+                  <is_optional>False</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>3</segment_ref>
+               </message_grammar>
+               <message_grammar id="5">
+                  <name>PD1</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>7</segment_ref>
+               </message_grammar>
+               <message_grammar id="6">
+                  <name>NTE</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>26</segment_ref>
+               </message_grammar>
+               <message_grammar id="7">
+                  <name>PATIENT_VISIT</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>group</type>
+                  <message_grammar id="8">
+                     <name>PV1</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>4</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="9">
+                     <name>PV2</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>11</segment_ref>
+                  </message_grammar>
+               </message_grammar>
+               <message_grammar id="10">
+                  <name>INSURANCE</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>group</type>
+                  <message_grammar id="11">
+                     <name>IN1</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>19</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="12">
+                     <name>IN2</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>20</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="13">
+                     <name>IN3</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>21</segment_ref>
+                  </message_grammar>
+               </message_grammar>
+               <message_grammar id="14">
+                  <name>GT1</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>18</segment_ref>
+               </message_grammar>
+               <message_grammar id="15">
+                  <name>AL1</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>14</segment_ref>
+               </message_grammar>
+            </message_grammar>
+            <message_grammar id="16">
+               <name>ORDER</name>
+               <is_optional>False</is_optional>
+               <is_repeating>True</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>group</type>
+               <message_grammar id="17">
+                  <name>ORC</name>
+                  <is_optional>False</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>27</segment_ref>
+               </message_grammar>
+               <message_grammar id="18">
+                  <name>ORDER_DETAIL</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>group</type>
+                  <message_grammar id="19">
+                     <name>OBR</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>28</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="20">
+                     <name>RQD</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>29</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="21">
+                     <name>RQ1</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>30</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="22">
+                     <name>RXO</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>31</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="23">
+                     <name>ODS</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>32</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="24">
+                     <name>ODT</name>
+                     <is_optional>False</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>33</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="25">
+                     <name>NTE</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>True</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>26</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="26">
+                     <name>CTD</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>False</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>34</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="27">
+                     <name>DG1</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>True</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>segment</type>
+                     <segment_ref>15</segment_ref>
+                  </message_grammar>
+                  <message_grammar id="28">
+                     <name>OBSERVATION</name>
+                     <is_optional>True</is_optional>
+                     <is_repeating>True</is_repeating>
+                     <ignore_segment_order>False</ignore_segment_order>
+                     <max_repeats>0</max_repeats>
+                     <type>group</type>
+                     <message_grammar id="29">
+                        <name>OBX</name>
+                        <is_optional>False</is_optional>
+                        <is_repeating>False</is_repeating>
+                        <ignore_segment_order>False</ignore_segment_order>
+                        <max_repeats>0</max_repeats>
+                        <type>segment</type>
+                        <segment_ref>13</segment_ref>
+                     </message_grammar>
+                     <message_grammar id="30">
+                        <name>NTE</name>
+                        <is_optional>True</is_optional>
+                        <is_repeating>True</is_repeating>
+                        <ignore_segment_order>False</ignore_segment_order>
+                        <max_repeats>0</max_repeats>
+                        <type>segment</type>
+                        <segment_ref>26</segment_ref>
+                     </message_grammar>
+                  </message_grammar>
+               </message_grammar>
+               <message_grammar id="31">
+                  <name>FT1</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>35</segment_ref>
+               </message_grammar>
+               <message_grammar id="32">
+                  <name>CT1</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>True</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>42</segment_ref>
+               </message_grammar>
+               <message_grammar id="33">
+                  <name>BLG</name>
+                  <is_optional>True</is_optional>
+                  <is_repeating>False</is_repeating>
+                  <ignore_segment_order>False</ignore_segment_order>
+                  <max_repeats>0</max_repeats>
+                  <type>segment</type>
+                  <segment_ref>37</segment_ref>
+               </message_grammar>
+            </message_grammar>
+         </message_grammar>
+         <identifier>
+            <segment_ref>MSH</segment_ref>
+            <value>ORU</value>
+            <node_address>
+               <pair>
+                  <node_index>8</node_index>
+                  <repeat_index>0</repeat_index>
+               </pair>
+               <pair>
+                  <node_index>0</node_index>
+                  <repeat_index>0</repeat_index>
+               </pair>
+            </node_address>
+         </identifier>
+         <table_grammar name="Lab">
+            <type>group</type>
+            <grammar_field_index>-1</grammar_field_index>
+            <grammar_root_ref>0</grammar_root_ref>
+            <table_grammar name="patient">
+               <type>table</type>
+               <grammar_field_index>-1</grammar_field_index>
+               <mapset_ref>Mapset</mapset_ref>
+            </table_grammar>
+            <table_grammar name="kin">
+               <type>table</type>
+               <grammar_field_index>-1</grammar_field_index>
+               <mapset_ref>Mapset</mapset_ref>
+            </table_grammar>
+         </table_grammar>
+      </message>
+      <message name="Message1">
+         <ignore_unknown_segments>True</ignore_unknown_segments>
+         <ignore_segment_order>False</ignore_segment_order>
+         <in_equation><![CDATA[]]></in_equation>
+         <out_equation><![CDATA[]]></out_equation>
+         <message_grammar id="0">
+            <name>Message</name>
+            <is_optional>False</is_optional>
+            <is_repeating>False</is_repeating>
+            <ignore_segment_order>False</ignore_segment_order>
+            <max_repeats>0</max_repeats>
+            <type>group</type>
+            <message_grammar id="1">
+               <name>MSH</name>
+               <is_optional>False</is_optional>
+               <is_repeating>False</is_repeating>
+               <ignore_segment_order>False</ignore_segment_order>
+               <max_repeats>0</max_repeats>
+               <type>segment</type>
+               <segment_ref>1</segment_ref>
+            </message_grammar>
+         </message_grammar>
+         <table_grammar name="Message1">
+            <type>group</type>
+            <grammar_field_index>-1</grammar_field_index>
+            <grammar_root_ref>0</grammar_root_ref>
+         </table_grammar>
+      </message>
+      <app_settings>
+         <config name="default">
+            <eom_char>0</eom_char>
+            <octal_escape_char>48</octal_escape_char>
+            <escape_default>92</escape_default>
+            <escape_escape_char>69</escape_escape_char>
+            <escape_position>6</escape_position>
+            <stub_file_dir><![CDATA[c:\temp]]></stub_file_dir>
+            <stub_file_language></stub_file_language>
+            <stub_file_prefix>HL7</stub_file_prefix>
+            <output_trailing_separators>True</output_trailing_separators>
+            <parse_separator_chars>True</parse_separator_chars>
+            <lowest_unescaped_char>32</lowest_unescaped_char>
+            <highest_unescaped_char>255</highest_unescaped_char>
+            <preset_config>HL7</preset_config>
+            <main_equation><![CDATA[]]></main_equation>
+            <parse_complete_equation><![CDATA[]]></parse_complete_equation>
+            <postprocess_equation><![CDATA[]]></postprocess_equation>
+            <main_out_equation><![CDATA[]]></main_out_equation>
+            <postprocess_out_equation><![CDATA[]]></postprocess_out_equation>
+            <output_segment_line_feed>False</output_segment_line_feed>
+            <xml_delimiter>46</xml_delimiter>
+            <xml_translation_type>STANDARD VER 2</xml_translation_type>
+            <use_segment_checker3>False</use_segment_checker3>
+            <xml_schema_single_file>True</xml_schema_single_file>
+            <header_fields_to_skip>3</header_fields_to_skip>
+            <disable_untyped_tree_in_exception>False</disable_untyped_tree_in_exception>
+            <maximum_repeat_mapping_limit>2</maximum_repeat_mapping_limit>
+            <database_equation_on>False</database_equation_on>
+            <disable_python_none>True</disable_python_none>
+            <header_segment>MSH</header_segment>
+            <last_message_matches_all>True</last_message_matches_all>
+            <parser_version>2</parser_version>
+            <separator_info>
+               <sep_char_default>13</sep_char_default>
+               <repeat_char_default>0</repeat_char_default>
+               <sep_char_escape>0</sep_char_escape>
+               <repeat_char_escape>0</repeat_char_escape>
+               <sep_char_position>-1</sep_char_position>
+               <repeat_char_position>-1</repeat_char_position>
+            </separator_info>
+            <separator_info>
+               <sep_char_default>124</sep_char_default>
+               <repeat_char_default>126</repeat_char_default>
+               <sep_char_escape>70</sep_char_escape>
+               <repeat_char_escape>82</repeat_char_escape>
+               <sep_char_position>3</sep_char_position>
+               <repeat_char_position>5</repeat_char_position>
+            </separator_info>
+            <separator_info>
+               <sep_char_default>94</sep_char_default>
+               <repeat_char_default>0</repeat_char_default>
+               <sep_char_escape>83</sep_char_escape>
+               <repeat_char_escape>0</repeat_char_escape>
+               <sep_char_position>4</sep_char_position>
+               <repeat_char_position>-1</repeat_char_position>
+            </separator_info>
+            <separator_info>
+               <sep_char_default>38</sep_char_default>
+               <repeat_char_default>0</repeat_char_default>
+               <sep_char_escape>84</sep_char_escape>
+               <repeat_char_escape>0</repeat_char_escape>
+               <sep_char_position>7</sep_char_position>
+               <repeat_char_position>-1</repeat_char_position>
+            </separator_info>
+            <connection_info>
+               <label></label>
+               <api></api>
+               <db_name></db_name>
+               <username></username>
+               <password></password>
+            </connection_info>
+            <escape_data_for_xml_to_hl7>True</escape_data_for_xml_to_hl7>
+            <validate_data_for_xml_to_hl7>True</validate_data_for_xml_to_hl7>
+         </config>
+      </app_settings>
+   </config>
+</engine>

--- a/other/tables.dbs
+++ b/other/tables.dbs
@@ -1,0 +1,10 @@
+create table Patient
+(
+   Id string,
+   FirstName string,
+   LastName string,
+   Gender string,
+   primary key (Id)
+);
+
+group ADT ( Patient );

--- a/shared/dbs_meta.lua
+++ b/shared/dbs_meta.lua
@@ -1,0 +1,51 @@
+-- Put appropriate quotes around table/column name
+function dbs_quote_name(Name)
+   if     string.find(Name,'"')==nil then return '"' .. Name .. '"'
+   elseif string.find(Name,"'")==nil then return "'" .. Name .. "'"
+   elseif string.find(Name,"`")==nil then return "`" .. Name .. "`"
+   elseif string.find(Name,"]")==nil then return "[" .. Name .. "]"
+   else return Name end
+end
+
+-- Check if table exists in DB
+function dbs_exists_table(Connection, Name)
+   local api = Connection:info().api
+   if api == db.SQLITE then
+      return 0 < #Connection:query{sql="SELECT 1 FROM sqlite_master WHERE type='table' and name=" .. dbs_quote_name(Name), live=true }
+   end
+   return false;
+end
+
+-- Automatically creates tables if they do not already exist based on dbs schema
+-- SQLite implementation only
+function dbs_create_tables(Connection, Schema) 
+   if Connection==nil or Connection:info().live==false or Connection:info().api~=db.SQLITE  then return false end
+   local Tables = Schema:getTableSet()
+   for i=1,#Tables,1 do
+      if dbs_exists_table(Connection,Tables[i]:nodeName())==false then
+         local Keys = nil
+         local Stmt = "create table " .. dbs_quote_name(Tables[i]:nodeName()) .. " ( " 
+         local Columns = Tables[i][1]
+         for j=1,#Columns,1 do
+            local Column  = dbs_quote_name(Columns[j]:nodeName())
+            local ColType = Columns[j]:nodeType()
+            if j~=1 then Stmt = Stmt .. " , " end
+            Stmt = Stmt .. Column
+            if     ColType == 'string'   then Stmt = Stmt .. " VARCHAR(255)"
+            elseif ColType == 'integer'  then Stmt = Stmt .. " INTEGER"
+            elseif ColType == 'double'   then Stmt = Stmt .. " DOUBLE PRECISION"
+            elseif ColType == 'datetime' then Stmt = Stmt .. " TIMESTAMP"
+            else                              Stmt = Stmt .. " VARCHAR(255)" end
+            if Columns[j]:isKey() then
+               if Keys==nil then Keys = Column
+               else              Keys = Keys .. " , " .. Column end
+               Stmt = Stmt .. " NOT NULL"
+            end
+         end
+         if Keys ~= nil then Stmt = Stmt .. " , PRIMARY KEY (" .. Keys .. ")" end
+         Stmt = Stmt .. " )"
+         Connection:execute{sql=Stmt, live=true}
+      end
+   end
+   return true
+end


### PR DESCRIPTION
Example showing usage of dbs files instead of vmd files for storing table
schema information.  The example does the same thing as the
Socket to Database demo channel.  Also this example uses dbs_meta
shared module to automatically create the table if it is missing
the database.
